### PR TITLE
Fix 'testClasses not found in project' Android Studio build error

### DIFF
--- a/CurrencyApp/.fleet/settings.json
+++ b/CurrencyApp/.fleet/settings.json
@@ -1,0 +1,3 @@
+{
+    "run.destination.stop.already.running": "Always"
+}

--- a/CurrencyApp/composeApp/build.gradle.kts
+++ b/CurrencyApp/composeApp/build.gradle.kts
@@ -18,9 +18,9 @@ kotlin {
             jvmTarget.set(JvmTarget.JVM_11)
         }
     }
-    
+
     jvm("desktop")
-    
+
     listOf(
         iosX64(),
         iosArm64(),
@@ -31,10 +31,10 @@ kotlin {
             isStatic = true
         }
     }
-    
+
     sourceSets {
         val desktopMain by getting
-        
+
         androidMain.dependencies {
             implementation(compose.preview)
             implementation(libs.androidx.activity.compose)
@@ -111,6 +111,15 @@ android {
     buildFeatures {
         compose = true
     }
+    composeOptions {
+        // Hardcoding version due to IDE IntelliSense bug with Version Catalogs.
+        // kotlinCompilerExtensionVersion = libs.versions.androidxComposeCompiler.get()
+        // kotlinCompilerExtensionVersion = libs.versions.kotlin.get()
+
+        // Compose to Kotlin Compatibility Map
+        // https://developer.android.com/jetpack/androidx/releases/compose-kotlin
+        kotlinCompilerExtensionVersion = "2.0.0"
+    }
     dependencies {
         debugImplementation(compose.uiTooling)
     }
@@ -126,4 +135,10 @@ compose.desktop {
             packageVersion = "1.0.0"
         }
     }
+}
+
+// Resolves KMP gradle build error for Android Studio:
+// Task 'testClasses' not found in project ':module'
+task("testClasses").doLast {
+    project.logger.lifecycle("Task 'testClasses' does not do anything.")
 }

--- a/CurrencyApp/composeApp/src/commonMain/kotlin/presentation/component/HomeHeader.kt
+++ b/CurrencyApp/composeApp/src/commonMain/kotlin/presentation/component/HomeHeader.kt
@@ -81,7 +81,6 @@ fun RatesStatus(
             Spacer(modifier = Modifier.width(12.dp))
             Column {
                 Text(
-                    // TODO: Display current Date & Time
                     text = displayCurrentDateTime(),
                     color = Color.White
                 )

--- a/README.md
+++ b/README.md
@@ -99,6 +99,17 @@ Find Fleet IDE action --> `CMD + Shift + K`
 | :--------------------------------: |
 | ![Kotlin Multiplatform Mobile Plugin](Screenshots/kotlin-multiplatform-plugin.png) |
 
+## TODO: Android Compose Multiplatform Plugin
+
+To resolve the Android Studio `testClasses` build error, refer to:  
+https://youtrack.jetbrains.com/issue/IDEA-340516  
+https://stackoverflow.com/questions/78133592/kmm-project-build-error-testclasses-not-found-in-project-shared  
+```kotlin
+task("testClasses").doLast {
+    project.logger.lifecycle("Task 'testClasses' does not do anything.")
+}
+```
+
 
 # Running the Project
 


### PR DESCRIPTION
To resolve the Android Studio `testClasses` build error, refer to:
https://youtrack.jetbrains.com/issue/IDEA-340516
https://stackoverflow.com/questions/78133592/kmm-project-build-error-testclasses-not-found-in-project-shared

```
FAILURE: Build failed with an exception.

* What went wrong:
Cannot locate tasks that match ':composeApp:testClasses' as task 
'testClasses' not found in project ':composeApp'.
```